### PR TITLE
Fix waxdev docker binary path

### DIFF
--- a/Dockerfile.node.dev
+++ b/Dockerfile.node.dev
@@ -23,5 +23,5 @@ RUN mkdir build && cd build &&                                                  
     make -j $(nproc) package
     
 ENV EOSIO_ROOT=/tmp/wax-blockchain
-ENV PATH="/tmp/wax-blockchain/bin:${PATH}"
+ENV PATH="/tmp/wax-blockchain/build/bin:${PATH}"
 ENV LEAP_BUILD_PATH=/tmp/wax-blockchain/build

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,9 @@ tag-node-image:
 	docker tag waxteam/waxnode waxteam/waxnode:$(WAX_VERSION)
 	docker tag waxteam/waxnode-dev waxteam/waxnode-dev:$(WAX_VERSION)
 
+tag-node-image-dev:
+	docker tag waxteam/waxnode-dev waxteam/waxnode-dev:$(WAX_VERSION)
+
 push-node-image:
 	docker tag waxteam/waxnode waxteam/waxnode:$(WAX_VERSION)
 	docker push waxteam/waxnode:$(WAX_VERSION)
@@ -95,4 +98,5 @@ push-cdt-image-dev:
 	docker push waxteam/waxdev:latest
 
 build-all: build-node-image build-node-image-dev tag-node-image build-cdt-image build-cdt-image-dev
+build-dev: build-node-image-dev tag-node-image-dev build-cdt-image-dev
 push-all: push-node-image push-node-image-dev push-cdt-image push-cdt-image-dev


### PR DESCRIPTION
Fix the path include on $PATH to /tmp/wax-blockchain/build/bin